### PR TITLE
Implement password hashing

### DIFF
--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -5,7 +5,8 @@ mongoose.connect('mongodb+srv://admin:nI4PpT3NUtTjIdML@cluster0.s1bp51g.mongodb.
 const userSchema = new mongoose.Schema({
     email: String,
     username: String,
-    password: String,
+    passwordHash: String,
+    salt: String,
 });
 
 const chatSchema = new mongoose.Schema({

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -2,6 +2,7 @@ const { Router } = require("express");
 const { User } = require("../db");
 const jwt = require("jsonwebtoken");
 const authMiddleware = require("../middleware/authMiddleware");
+const { hashPassword, verifyPassword } = require("../utils/password");
 const JWT_SECRET = "ForzaFerrari#2024";
 const { ObjectId } = require("mongodb");
 
@@ -17,10 +18,12 @@ router.post('/signup', async (req, res) => {
     });
 
     if (!response){
+        const { salt, hash } = hashPassword(password);
         const newUser = await User.create({
             email,
-            password,
-            username
+            username,
+            passwordHash: hash,
+            salt
         });
         try{
             const token = jwt.sign({
@@ -48,22 +51,16 @@ router.post('/signin', async (req, res) => {
     const email = req.body.email;
     const password = req.body.password;
 
-    console.log("EMAIL IS " + email);
-    console.log("PASSWORD IS " + password);
+    const user = await User.findOne({ email });
 
-    const response = await User.findOne({
-        email,
-        password,
-    });
-
-    if (response){
+    if (user && verifyPassword(password, user.salt, user.passwordHash)){
         try {
             const token = jwt.sign({
                 email,
             }, JWT_SECRET);
             res.json({
                 msg: "Login successful",
-                id: response.id,
+                id: user.id,
                 token
             });
         } catch (e){

--- a/backend/utils/password.js
+++ b/backend/utils/password.js
@@ -1,0 +1,15 @@
+const crypto = require('crypto');
+
+function hashPassword(password) {
+    const salt = crypto.randomBytes(16).toString('hex');
+    const hash = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+    return { salt, hash };
+}
+
+function verifyPassword(password, salt, hash) {
+    const hashed = crypto.pbkdf2Sync(password, salt, 1000, 64, 'sha512');
+    const stored = Buffer.from(hash, 'hex');
+    return crypto.timingSafeEqual(hashed, stored);
+}
+
+module.exports = { hashPassword, verifyPassword };


### PR DESCRIPTION
## Summary
- hash user passwords using Node crypto
- store `passwordHash` and `salt` in User model
- validate credentials with new helper functions

## Testing
- `npm test` in `/workspace/chatyhb/backend` *(fails: Error: no test specified)*
- `npm test` in `/workspace/chatyhb/frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685d80a729a48332a4ba269ff6281d75